### PR TITLE
fix migration

### DIFF
--- a/scripts/services/getConfig.ts
+++ b/scripts/services/getConfig.ts
@@ -254,12 +254,6 @@ export const getConfig: T.ExpectedExports.getConfig = async (effects) => {
               description: "Only connect to peers over Tor.",
               default: false,
             },
-            v2transport: {
-              type: "boolean",
-              name: "Use V2 P2P Transport Protocol",
-              description: "Enable or disable the use of BIP324 V2 P2P transport protocol.",
-              default: false,
-            },
             addnode: {
               name: "Add Nodes",
               description: "Add addresses of nodes to connect to.",

--- a/scripts/services/migrations.ts
+++ b/scripts/services/migrations.ts
@@ -229,26 +229,30 @@ export const migration: T.ExpectedExports.migration =
           { version: "25.0.0.2", type: "down" }
         ),
       },
-      "26.0.0": {
+      "25.1.0": {
         up: compat.migrations.updateConfig(
           (config: any) => {
-            config.advanced.peers.v2transport = false;
+            config.datacarrier = true;
+            config.datacarriersize = 83;
+            config.permitbaremultisig = false;
 
             return config;
           },
           true,
-          { version: "26.0.0", type: "up" }
+          { version: "25.1.0", type: "up" }
         ),
         down: compat.migrations.updateConfig(
           (config: any) => {
-            delete config.advanced.peers.v2transport;
+            delete config.datacarrier;
+            delete config.datacarriersize;
+            delete config.permitbaremultisig;
 
             return config;
           },
           true,
-          { version: "26.0.0", type: "down" }
+          { version: "25.1.0", type: "down" }
         ),
       },
     },
-    "26.0.0"
+    "25.1.0"
   );


### PR DESCRIPTION
The migration was messed up in two ways:

- technically v2transport doesn't exist yet and that will screw up trying to upgrade and downgrade with normal bitcoin core (switching back and forth between knots and core will probably always be awkward until support for two different packages with the same name is supported upstream)
- datacarrier, datacarriersize, and permitbaremultisig weren't being initialized, resulting in this message upon installation:

![Screenshot from 2024-02-14 14-50-25](https://github.com/Retropex/ordisrespector-startos/assets/7445670/2a4bf33e-efa8-4bf8-8629-231b837b273f)


This PR fixes both issues.