### PR TITLE
Sync peerPort and whitebind with Core settings

### DIFF
--- a/startos/actions/config/peers.ts
+++ b/startos/actions/config/peers.ts
@@ -155,7 +155,7 @@ async function read(effects: any): Promise<PartialPeerSpec> {
 async function write(effects: T.Effects, input: PeerSpec) {
   const peerSettings = {
     listen: input.listen,
-    bind: input.listen ? '0.0.0.0:8333' : bind,
+    bind: input.listen ? '0.0.0.0:18333' : bind,
     v2transport: input.v2transport,
     onlynet: input.onlynet,
     externalip: input.externalip !== 'none' ? input.externalip : externalip,

--- a/startos/fileModels/bitcoin.conf.ts
+++ b/startos/fileModels/bitcoin.conf.ts
@@ -32,7 +32,7 @@ const {
   rpcthreads,
   rpcworkqueue,
   rpccookiefile,
-  whitelist,
+  whitebind,
   bind,
   persistmempool,
   maxmempool,
@@ -160,7 +160,7 @@ export const shape = object({
   blocknotify: string.optional().onMismatch(blocknotify),
 
   // Whitelist
-  whitelist: stringArray.orParser(string).optional().onMismatch(whitelist),
+  whitebind: stringArray.orParser(string).optional().onMismatch(whitebind),
 
   // Pruning
   prune: natural.onMismatch(prune),

--- a/startos/fileModels/bitcoin.conf.ts
+++ b/startos/fileModels/bitcoin.conf.ts
@@ -159,7 +159,7 @@ export const shape = object({
   // Blocknotify
   blocknotify: string.optional().onMismatch(blocknotify),
 
-  // Whitelist
+  // Whitebind
   whitebind: stringArray.orParser(string).optional().onMismatch(whitebind),
 
   // Pruning

--- a/startos/utils.ts
+++ b/startos/utils.ts
@@ -3,7 +3,7 @@ export const rpcInterfaceId = 'rpc'
 export const peerInterfaceId = 'peer'
 export const zmqInterfaceId = 'zmq'
 export const zmqPort = 28332
-export const peerPort = 8333
+export const peerPort = 18333
 export const rpcPort = 8332
 
 export const rootDir = '/.bitcoin'
@@ -69,7 +69,7 @@ export const bitcoinConfDefaults = {
   rpcthreads: 4,
   rpcworkqueue: 16,
   rpccookiefile: '.cookie',
-  whitelist: ['172.18.0.0/16'],
+  whitebind: '0.0.0.0:8333',
   bind: undefined,
 
   // Mempool


### PR DESCRIPTION
- Switch peerPort to 18333 to avoid port collision when switching from Knots -> Core or vice versa.
- Use `whitebind` instead of `whitelist` to only whitelist local connections