### PR TITLE
IDB optimizations

### DIFF
--- a/assets/compat/bitcoin.conf.template
+++ b/assets/compat/bitcoin.conf.template
@@ -130,6 +130,10 @@ prune={{advanced.pruning.size}}
 {{#IF advanced.dbcache
 dbcache={{advanced.dbcache}}
 }}
+{{#IF advanced.dbbatchsize
+dbbatchsize={{advanced.dbbatchsize}}
+}}
+assumevalid=00000000000000000000611fd22f2df7c8fbd0688745c3a6c3bb5109cc2a12cb
 
 ## WALLET
 {{#IF !wallet.enable

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -4,6 +4,7 @@ version: 29.2.0
 eos-version: 0.3.5.1
 release-notes: |
   * Latest release from Knots - see full release notes [here](https://github.com/bitcoinknots/bitcoin/releases/tag/v29.2.knots20251010)
+  * IBD performance optimizations
 license: MIT
 wrapper-repo: https://github.com/Retropex/knots-startos
 upstream-repo: https://github.com/bitcoinknots/bitcoin/

--- a/scripts/services/getConfig.ts
+++ b/scripts/services/getConfig.ts
@@ -595,10 +595,20 @@ export const getConfig: T.ExpectedExports.getConfig = async (effects) => {
           nullable: true,
           name: "Database Cache",
           description:
-            "How much RAM to allocate for caching the TXO set. Higher values improve syncing performance, but increase your chance of using up all your system's memory or corrupting your database in the event of an ungraceful shutdown. Set this high but comfortably below your system's total RAM during IBD, then turn down to 450 (or leave blank) once the sync completes.",
-          warning:
-            "WARNING: Increasing this value results in a higher chance of ungraceful shutdowns, which can leave your node unusable if it happens during the initial block download. Use this setting with caution. Be sure to set this back to the default (450 or leave blank) once your node is synced. DO NOT press the STOP button if your dbcache is large. Instead, set this number back to the default, hit save, and wait for bitcoind to restart on its own.",
+            "How much RAM to allocate for caching the TXO set. Higher values improve syncing performance, but may result in some re-work in the event of an ungraceful shutdown. 4-7GB is high enough to get most of the peformance benefit during IBD. Consider reducing this setting for lower resource devices (or a device with less available RAM)",
           range: "(0,*)",
+          default: 5_000,
+          integral: true,
+          units: "MiB",
+        },
+        dbbatchsize: {
+          type: "number",
+          nullable: true,
+          name: "Database Batch",
+          description:
+            "Maximum database write batch size in bytes. Higher values will speed up the critical sections when the utxo set is written to disk from memory in big batches.",
+          range: "(0,*)",
+          default: 33_554_432,
           integral: true,
           units: "MiB",
         },

--- a/scripts/services/getConfig.ts
+++ b/scripts/services/getConfig.ts
@@ -610,7 +610,7 @@ export const getConfig: T.ExpectedExports.getConfig = async (effects) => {
           range: "(0,*)",
           default: 33_554_432,
           integral: true,
-          units: "MiB",
+          units: "bytes",
         },
         blocknotify: {
           type: "string",

--- a/scripts/services/getConfig.ts
+++ b/scripts/services/getConfig.ts
@@ -597,7 +597,6 @@ export const getConfig: T.ExpectedExports.getConfig = async (effects) => {
           description:
             "How much RAM to allocate for caching the TXO set. Higher values improve syncing performance, but may result in some re-work in the event of an ungraceful shutdown. 4-7GB is high enough to get most of the peformance benefit during IBD. Consider reducing this setting for lower resource devices (or a device with less available RAM)",
           range: "(0,*)",
-          default: 5_000,
           integral: true,
           units: "MiB",
         },


### PR DESCRIPTION
- Default `dbcache` to 5,000 MiB
- Default `dbbatchsize` to 33,554,432 (32 MiB)
- Use latest blockhash for `assumevalid`