### PR TITLE
Replace RPC port-listening health check with bitcoin-cli uptime

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > **Upstream docs:** <https://bitcoinknots.org/>
 >
 > Everything not listed in this document should behave the same as upstream
-> Bitcoin Knots v29.3. If a feature, setting, or behavior is not mentioned
+> Bitcoin Knots. If a feature, setting, or behavior is not mentioned
 > here, the upstream documentation is accurate and fully applicable.
 
 An enhanced Bitcoin full node implementation with additional policy controls for mempool filtering and spam prevention. See the [upstream repo](https://github.com/bitcoinknots/bitcoin) for general Bitcoin Knots documentation.
@@ -40,7 +40,7 @@ This package shares the `bitcoind` package ID with [Bitcoin Core](https://github
 
 | Property      | Value                                                                        |
 | ------------- | ---------------------------------------------------------------------------- |
-| Image         | Custom Dockerfile (multi-stage Alpine build from Bitcoin Knots v29.3 source) |
+| Image         | Custom Dockerfile (multi-stage Alpine build from Bitcoin Knots source)       |
 | Architectures | x86_64, aarch64, riscv64                                                     |
 | Entrypoint    | `bitcoind`                                                                   |
 
@@ -51,8 +51,8 @@ Three additional containers are used:
 | Container | Image                              | Purpose                                       |
 | --------- | ---------------------------------- | --------------------------------------------- |
 | `proxy`   | `ghcr.io/start9labs/btc-rpc-proxy` | RPC proxy for pruned nodes                    |
-| `python`  | `python:3.13.11-alpine`            | Runs `rpcauth.py` to generate RPC credentials |
-| `i2pd`    | `purplei2p/i2pd:release-2.58.0`    | Embedded I2P daemon (when enabled)            |
+| `python`  | `python` (Alpine)                  | Runs `rpcauth.py` to generate RPC credentials |
+| `i2pd`    | `purplei2p/i2pd`                   | Embedded I2P daemon (when enabled)            |
 
 ## Volume and Data Layout
 
@@ -205,7 +205,7 @@ This is transparent to dependent services — port 8332 always serves RPC.
 
 | Check              | Method                                                  | Messages                                                                            |
 | ------------------ | ------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| **RPC**            | Waits for `.cookie` file, then port listening            | Ready: "The Bitcoin RPC Interface is ready"                                         |
+| **RPC**            | Waits for `.cookie` file, then `bitcoin-cli uptime`      | Ready: "The Bitcoin RPC Interface is ready"                                         |
 | **Blockchain Sync**| `bitcoin-cli getblockchaininfo`                         | Shows percentage during IBD; "Bitcoin is fully synced" when complete                |
 | **I2P**            | I2PControl API status check                             | Ready/not ready based on I2P daemon state                                           |
 | **Tor**            | Tor proxy reachability                                  | Ready when Tor connection is available                                              |
@@ -295,13 +295,12 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for build instructions and development wo
 
 ```yaml
 package_id: bitcoind
-upstream_version: '29.3'
 flavor: knots
-image: custom Dockerfile (built from Bitcoin Knots v29.3 source)
+image: custom Dockerfile (built from Bitcoin Knots source)
 additional_images:
   - ghcr.io/start9labs/btc-rpc-proxy (pruned node RPC proxy)
-  - python:3.13.11-alpine (RPC credential generation)
-  - purplei2p/i2pd:release-2.58.0 (embedded I2P)
+  - python (Alpine, RPC credential generation)
+  - purplei2p/i2pd (embedded I2P)
 architectures: [x86_64, aarch64, riscv64]
 volumes:
   main: /root/.bitcoin
@@ -340,7 +339,7 @@ actions:
   - restore-wallet
   - remove-wallet
 health_checks:
-  - rpc: port_listening (after .cookie file exists)
+  - rpc: bitcoin-cli_uptime (after .cookie file exists)
   - sync-progress: bitcoin-cli_getblockchaininfo
   - i2p: i2pcontrol_api / status
   - tor: proxy reachability

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,14 +20,10 @@
     },
     "node_modules/@iarna/toml": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-3.0.0.tgz",
-      "integrity": "sha512-td6ZUkz2oS3VeleBcN+m//Q6HlCFCPrnI0FZhrt/h4XqLEdOyYp2u21nd8MdsR+WJy5r9PTDaHTDDfhf4H4l6Q==",
       "license": "ISC"
     },
     "node_modules/@noble/curves": {
       "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.8.0"
@@ -41,8 +37,6 @@
     },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -53,8 +47,6 @@
     },
     "node_modules/@start9labs/start-sdk": {
       "version": "0.4.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-0.4.0-beta.66.tgz",
-      "integrity": "sha512-fsp7d3nqFapLohaKbNk1frW8fbVmjr2CBehVXVUk6JS/LSerogqlAYUFE5LKp5vJoTkuSnZbF5np4m+oxCmwCw==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -73,14 +65,10 @@
     },
     "node_modules/@types/ini": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@types/ini/-/ini-4.1.1.tgz",
-      "integrity": "sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -89,8 +77,6 @@
     },
     "node_modules/@vercel/ncc": {
       "version": "0.38.4",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.4.tgz",
-      "integrity": "sha512-8LwjnlP39s08C08J5NstzriPvW1SP8Zfpp1BvC2sI35kPeZnHfxVkCwu4/+Wodgnd60UtT1n8K8zw+Mp7J9JmQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -99,7 +85,7 @@
     },
     "node_modules/bitcoin-core-startos": {
       "name": "bitcoin-core",
-      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#113731eaf28e13e6a6ecd343c409a9528f458a5b",
+      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#249c72e07258de60594ffd73cac13a894e470af6",
       "dependencies": {
         "@start9labs/start-sdk": "^0.4.0-beta.66",
         "diskusage": "^1.2.0",
@@ -108,8 +94,6 @@
     },
     "node_modules/deep-equality-data-structures": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/deep-equality-data-structures/-/deep-equality-data-structures-2.0.0.tgz",
-      "integrity": "sha512-qgrUr7MKXq7VRN+WUpQ48QlXVGL0KdibAoTX8KRg18lgOgqbEKMAW1WZsVCtakY4+XX42pbAJzTz/DlXEFM2Fg==",
       "license": "MIT",
       "dependencies": {
         "object-hash": "^3.0.0"
@@ -117,9 +101,6 @@
     },
     "node_modules/diskusage": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/diskusage/-/diskusage-1.2.0.tgz",
-      "integrity": "sha512-2u3OG3xuf5MFyzc4MctNRUKjjwK+UkovRYdD2ed/NZNZPrt0lqHnLKxGhlFVvAb4/oufIgQG3nWgwmeTbHOvXA==",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "es6-promise": "^4.2.8",
@@ -128,14 +109,10 @@
     },
     "node_modules/es6-promise": {
       "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "funding": [
         {
           "type": "github",
@@ -149,8 +126,6 @@
     },
     "node_modules/fast-xml-parser": {
       "version": "5.5.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
-      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
       "funding": [
         {
           "type": "github",
@@ -169,8 +144,6 @@
     },
     "node_modules/ini": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-5.0.0.tgz",
-      "integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==",
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -178,8 +151,6 @@
     },
     "node_modules/isomorphic-fetch": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.1",
@@ -188,8 +159,6 @@
     },
     "node_modules/mime": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
-      "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
       "funding": [
         "https://github.com/sponsors/broofa"
       ],
@@ -203,14 +172,10 @@
     },
     "node_modules/nan": {
       "version": "2.26.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
-      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
       "license": "MIT"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -229,8 +194,6 @@
     },
     "node_modules/object-hash": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -238,8 +201,6 @@
     },
     "node_modules/path-expression-matcher": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
       "funding": [
         {
           "type": "github",
@@ -253,8 +214,6 @@
     },
     "node_modules/prettier": {
       "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -269,14 +228,10 @@
     },
     "node_modules/rfc4648": {
       "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.4.tgz",
-      "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
       "license": "MIT"
     },
     "node_modules/strnum": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
       "funding": [
         {
           "type": "github",
@@ -286,7 +241,7 @@
       "license": "MIT"
     },
     "node_modules/tor-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/tor-startos.git#99b7401c887bb4064fa179f8678997914f484ef7",
+      "resolved": "git+ssh://git@github.com/Start9Labs/tor-startos.git#c2ede4b76d3983b67297d00332a8e200a5b8e6c0",
       "dependencies": {
         "@noble/curves": "*",
         "@start9labs/start-sdk": "^0.4.0-beta.66",
@@ -295,14 +250,10 @@
     },
     "node_modules/tr46": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -315,27 +266,19 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
-      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -344,8 +287,6 @@
     },
     "node_modules/yaml": {
       "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -359,8 +300,6 @@
     },
     "node_modules/zod": {
       "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -369,8 +308,6 @@
     },
     "node_modules/zod-deep-partial": {
       "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/zod-deep-partial/-/zod-deep-partial-1.4.4.tgz",
-      "integrity": "sha512-aWkPl7hVStgE01WzbbSxCgX4O+sSpgt8JOjvFUtMTF75VgL6MhWQbiZi+AWGN85SfSTtI9gsOtL1vInoqfDVaA==",
       "license": "MIT",
       "peerDependencies": {
         "zod": "^4.1.13"

--- a/startos/init/index.ts
+++ b/startos/init/index.ts
@@ -8,9 +8,9 @@ import { seedFiles } from './seedFiles'
 import { taskSetExternal } from './taskSetExternal'
 
 export const init = sdk.setupInit(
-  seedFiles,
   restoreInit,
   versionGraph,
+  seedFiles,
   setInterfaces,
   setDependencies,
   actions,

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -178,14 +178,23 @@ export const main = sdk.setupMain(async ({ effects }) => {
             }
           }
 
-          return sdk.healthCheck.checkPortListening(
-            effects,
-            bitcoinConf.prune ? rpcPortPruned : rpcPort,
-            {
-              successMessage: i18n('The Bitcoin RPC Interface is ready'),
-              errorMessage: i18n('The Bitcoin RPC Interface is not ready'),
-            },
-          )
+          const res = await bitcoindSub.exec([
+            ...bitcoinCliArgs({ prune: !!bitcoinConf.prune }),
+            '-rpcconnect=127.0.0.1',
+            'uptime',
+          ])
+
+          if (res.exitCode === 0) {
+            return {
+              message: i18n('The Bitcoin RPC Interface is ready'),
+              result: 'success',
+            }
+          }
+
+          return {
+            message: i18n('The Bitcoin RPC Interface is not ready'),
+            result: 'starting',
+          }
         },
       },
       requires: ['nocow'],

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,10 +1,10 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v29_3_1_b9 } from './v29.3_1.b9'
-import { v_28_3_5_b5 as core28_3 } from 'bitcoin-core-startos/startos/versions/v28.3.5.b5'
-import { v_29_3_5_b5 as core29_3 } from 'bitcoin-core-startos/startos/versions/v29.3.5.b5'
-import { v_30_2_5_b5 as core30_2 } from 'bitcoin-core-startos/startos/versions/v30.2.5.b5'
+import { v29_3_1_b10 } from './v29.3_1.b10'
+import { v_28_3_5_b6 as core28_3 } from 'bitcoin-core-startos/startos/versions/v28.3.5.b6'
+import { v_29_3_5_b6 as core29_3 } from 'bitcoin-core-startos/startos/versions/v29.3.5.b6'
+import { v_30_2_5_b6 as core30_2 } from 'bitcoin-core-startos/startos/versions/v30.2.5.b6'
 
 export const versionGraph = VersionGraph.of({
-  current: v29_3_1_b9,
+  current: v29_3_1_b10,
   other: [core30_2, core29_3, core28_3],
 })

--- a/startos/versions/v29.3_1.b10.ts
+++ b/startos/versions/v29.3_1.b10.ts
@@ -1,7 +1,7 @@
 import { IMPOSSIBLE, VersionInfo } from '@start9labs/start-sdk'
-import { v_28_3_5_b5 } from 'bitcoin-core-startos/startos/versions/v28.3.5.b5'
-import { v_29_3_5_b5 } from 'bitcoin-core-startos/startos/versions/v29.3.5.b5'
-import { v_30_2_5_b5 } from 'bitcoin-core-startos/startos/versions/v30.2.5.b5'
+import { v_28_3_5_b6 } from 'bitcoin-core-startos/startos/versions/v28.3.5.b6'
+import { v_29_3_5_b6 } from 'bitcoin-core-startos/startos/versions/v29.3.5.b6'
+import { v_30_2_5_b6 } from 'bitcoin-core-startos/startos/versions/v30.2.5.b6'
 import { bitcoinConfFile } from '../fileModels/bitcoin.conf'
 /**
  * Reset all mempool settings to undefined so the new flavor's upstream
@@ -43,8 +43,8 @@ const mempoolReset = {
   minrelaymaturity: undefined,
 }
 
-export const v29_3_1_b9 = VersionInfo.of({
-  version: '#knots:29.3:1-beta.9',
+export const v29_3_1_b10 = VersionInfo.of({
+  version: '#knots:29.3:1-beta.10',
   releaseNotes: {
     en_US: 'Multiple bug fixes',
   },
@@ -52,7 +52,7 @@ export const v29_3_1_b9 = VersionInfo.of({
     up: async ({ effects }) => {},
     down: IMPOSSIBLE,
     other: {
-      [v_28_3_5_b5.options.version]: {
+      [v_28_3_5_b6.options.version]: {
         // Core → Knots
         up: async ({ effects }) => {
           await bitcoinConfFile.merge(effects, mempoolReset)
@@ -62,7 +62,7 @@ export const v29_3_1_b9 = VersionInfo.of({
           await bitcoinConfFile.merge(effects, mempoolReset)
         },
       },
-      [v_29_3_5_b5.options.version]: {
+      [v_29_3_5_b6.options.version]: {
         // Core → Knots: reset mempool so Knots upstream defaults apply
         up: async ({ effects }) => {
           await bitcoinConfFile.merge(effects, mempoolReset)
@@ -72,7 +72,7 @@ export const v29_3_1_b9 = VersionInfo.of({
           await bitcoinConfFile.merge(effects, mempoolReset)
         },
       },
-      [v_30_2_5_b5.options.version]: {
+      [v_30_2_5_b6.options.version]: {
         // Core → Knots
         up: async ({ effects }) => {
           await bitcoinConfFile.merge(effects, mempoolReset)
@@ -84,4 +84,4 @@ export const v29_3_1_b9 = VersionInfo.of({
       },
     },
   },
-}).satisfies(v_29_3_5_b5.options.version)
+}).satisfies(v_29_3_5_b6.options.version)


### PR DESCRIPTION
The SDK's checkPortListening reads the entire system TCP connection table via /proc/net/tcp, which can exceed the default 1 MB exec buffer during startup when many dependent services connect simultaneously. Switch to a lightweight bitcoin-cli uptime call that confirms RPC is genuinely responding without buffering system-wide connection state.

Also fixes init ordering (seed files after versionGraph) and updates bitcoin-core-startos dependency to beta.6.